### PR TITLE
Add French missing translations

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -50,7 +50,7 @@ fr:
         presentation: Presentation
       spree/order:
         checkout_complete: "Paiement complet"
-        completed_at: "Completed At"
+        completed_at: "Passée le"
         created_at: Order Date
         email: Customer E-Mail
         ip_address: "Adresse IP"
@@ -1055,7 +1055,7 @@ fr:
   show_deleted: "Afficher les éléments supprimés"
   show_incomplete_orders: "Afficher les commandes imcomplètes"
   show_only_complete_orders: "Afficher seulement les commandes complètes"
-  show_only_unfulfilled_orders: "Show only unfulfilled orders"
+  show_only_unfulfilled_orders: "Ne montrer que les commandes inachevées"
   show_out_of_stock_products: "Afficher les produits en rupture de stock"
   showing_first_n: "Les %{n} premiers"
   sign_up: "S'inscrire"


### PR DESCRIPTION
In relation to [openfoodnetwork/pull/1847](https://github.com/openfoodfoundation/openfoodnetwork/pull/1847).
Those translations are fixed in other branches (2-0-stable etc), so this PR fixes them until we upgrade Spree.